### PR TITLE
update gtk4.cr git branch from `master` to `main`

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -11,7 +11,7 @@ targets:
 dependencies:
   gtk4:
     github: hugopl/gtk4.cr
-    branch: master
+    branch: main
   hardware:
     github: crystal-community/hardware
   non-blocking-spawn:


### PR DESCRIPTION
Not sure when the branch name got changed upstream, but the example isn't compiling now.